### PR TITLE
Enable headless use via Agg engine, create plots directory if not exist

### DIFF
--- a/hotplot.py
+++ b/hotplot.py
@@ -1,3 +1,9 @@
+import os
+import matplotlib
+#Allow headless use
+if os.environ.get('DISPLAY') is None:
+    print("Falling back to Agg engine")
+    matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.colors
 import matplotlib.image
@@ -166,6 +172,9 @@ def plot_data(data, filename='plot.png',maxups=None,maxcoms=None,maxage=None,sho
     cbar = plt.colorbar(sm, cax = ax_cbar)
     cbar.set_label('age in hours')
     plt.subplots_adjust(wspace=0.05, hspace=0.2)
+    #Check existence of plots directory
+    if not os.path.exists("plots/"):
+        os.makedirs("plots/")
     plt.savefig('plots/'+filename, bbox_inches='tight')
     if show: plt.show()
     plt.close()


### PR DESCRIPTION
For use on servers without a display connected, matplotlib can be configured to use the Agg engine without Tkinter to generate plots to file. Also, hotplot wasn't checking if the ./plots directory existed first and would fail to create it.